### PR TITLE
SPF Fix

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -9,7 +9,7 @@ locals {
   spf_tmp = [
     for provider in var.spf_providers : local.spf_defaults[provider]
   ]
-  spf = [{
+  spf = length(spf_tmp) < 1 ? [] : [{
     name  = "@",
     type  = "TXT",
     ttl   = var.ttl_default,

--- a/locals.tf
+++ b/locals.tf
@@ -9,7 +9,7 @@ locals {
   spf_tmp = [
     for provider in var.spf_providers : local.spf_defaults[provider]
   ]
-  spf = length(spf_tmp) < 1 ? [] : [{
+  spf = length(local.spf_tmp) < 1 ? [] : [{
     name  = "@",
     type  = "TXT",
     ttl   = var.ttl_default,


### PR DESCRIPTION
During changes to one of the use cases of this repository, I spotted that when not specifying spf_providers, a record with `~all` was created. Hence, added logic to handle the empty SPF providers